### PR TITLE
Allow users to disable visual cues

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
     <div class="tl-btn-group">
       <a href title="Audio toggle" class="item audio-toggle"><i class="fa fa-2x fa-volume-up"></i></a>
       <a href title="Speech toggle" class="item speech-toggle"><i class="fa fa-2x fa-assistive-listening-systems"></i></a>
+      <a href title="Visual toggle" class="item visual-toggle"><i class="fa fa-2x fa-eye"></i></a>
     </div>
     <div id="overlay">
       <div class="wrapper">

--- a/scripts/game-space.js
+++ b/scripts/game-space.js
@@ -324,7 +324,7 @@ class GameSpace {
           await delay(300);
           await this.playLetterSoundAlike(letter);
         }
-        word.applyHint(word.currentLetterIndex);
+        word.pushUp(word.currentLetterIndex);
       }
       this.parent.header.updateProgressLights(this.letterScoreDict, theLetterIndex);
     } else {
@@ -363,7 +363,7 @@ class GameSpace {
             await delay(300);
             await this.playLetterSoundAlike(letter);
           }
-          word.applyHint(word.currentLetterIndex);
+          word.pushUp(word.currentLetterIndex);
         }
       }
     }

--- a/scripts/game-space.js
+++ b/scripts/game-space.js
@@ -180,8 +180,7 @@ class GameSpace {
 
     // Animate stuff immediately when first starting
     this.game.add.tween(word.pills[0].scale).to({ x: 1, y: 1 }, 250, Phaser.Easing.Exponential.Out, true, config.animations.SLIDE_START_DELAY);
-    this.game.add.tween(word.pills[0]).to({ y: config.GLOBALS.worldTop }, 400, Phaser.Easing.Exponential.Out, true, config.animations.SLIDE_END_DELAY + 200);
-    this.game.add.tween(word.letterObjects[0]).to({ y: config.GLOBALS.worldTop }, 400, Phaser.Easing.Exponential.Out, true, config.animations.SLIDE_END_DELAY + 200);
+    word.pushUp(0);
     word.letterObjects[0].addColor('#F1E4D4', 0);
     word.letterObjects[0].alpha = 1;
 

--- a/scripts/title-state.js
+++ b/scripts/title-state.js
@@ -24,6 +24,7 @@ class TitleState {
     this.game = game;
     this.have_audio = true;
     this.have_speech_assistive = true;
+    this.have_visual_cues = true;
     function clearEventHandlers () {
       window.removeEventListener('click', startClickEvent)
       document.removeEventListener('inputEvent', inputEvent)
@@ -37,6 +38,7 @@ class TitleState {
       document.querySelector('.tl-btn-group').style.display = 'none';
       this.game.have_audio = this.have_audio;
       this.game.have_speech_assistive = this.have_speech_assistive;
+      this.game.have_visual_cues = this.have_visual_cues;
       this.start();
       this.hasStarted = true;
     }
@@ -89,6 +91,19 @@ class TitleState {
     updateAudioToggles();
     audioToggle.addEventListener('click', onSoundToggle, true);
     speechToggle.addEventListener('click', onSpeechToggle, true);
+
+    // This toggle allows the user to enable or disable visual cues.
+    const visualToggle = document.querySelector('.visual-toggle');
+    const onVisualToggle = e => {
+      // TODO: If we use a <span> instead of a <a> for the toggle, we don't
+      //   need to call these two methods.
+      e.preventDefault();
+      e.stopPropagation();
+      this.have_visual_cues = !this.have_visual_cues;
+      const action = this.have_visual_cues ? 'remove' : 'add';
+      visualToggle.classList[action]('disabled');
+    };
+    visualToggle.addEventListener('click', onVisualToggle, true);
   }
 
   init(params) {

--- a/scripts/word.js
+++ b/scripts/word.js
@@ -134,11 +134,13 @@ class Word {
 
   async updateHint(textOnly) {
     if (this.hints.length !== 0) {
-      await delay(((!textOnly) ? config.animations.SLIDE_END_DELAY + 400 : 0));
       if (textOnly) {
         this.game.add.tween(this.hints[this.currentLetterIndex].text).to({ alpha: 1 }, 200, Phaser.Easing.Linear.In, true);
       } else {
-        this.game.add.tween(this.hints[this.currentLetterIndex].image).to({ alpha: 1 }, 200, Phaser.Easing.Linear.In, true);
+        await delay(config.animations.SLIDE_END_DELAY + 400);
+        if (this.game.have_visual_cues) {
+          this.game.add.tween(this.hints[this.currentLetterIndex].image).to({ alpha: 1 }, 200, Phaser.Easing.Linear.In, true);
+        }
         this.game.add.tween(this.hints[this.currentLetterIndex].text).to({ alpha: 1 }, 200, Phaser.Easing.Linear.In, true);
         // Play the sounds when hint image shows
         await this.playSounds(this.letterObjects[this.currentLetterIndex]);
@@ -178,7 +180,7 @@ class Word {
   }
 
   pushUp(i) {
-    if (this.parent.letterScoreDict[this.myLetters[i]] < config.app.LEARNED_THRESHOLD) {
+    if (this.parent.letterScoreDict[this.myLetters[i]] < config.app.LEARNED_THRESHOLD && this.game.have_visual_cues) {
       this.game.add.tween(this.letterObjects[i]).to({ y: config.GLOBALS.worldTop }, 400, Phaser.Easing.Exponential.Out, true, config.animations.SLIDE_END_DELAY + 200);
       this.game.add.tween(this.pills[i]).to({ y: config.GLOBALS.worldTop }, 400, Phaser.Easing.Exponential.Out, true, config.animations.SLIDE_END_DELAY + 200);
     }

--- a/scripts/word.js
+++ b/scripts/word.js
@@ -169,7 +169,7 @@ class Word {
   }
 
   setStyle(i) {
-    this.applyHint(i);
+    this.pushUp(i);
     this.game.add.tween(this.letterObjects[i]).to({ alpha: 1 }, 200, Phaser.Easing.Linear.Out, true, config.animations.SLIDE_END_DELAY + 200);
 
     setTimeout(() => {
@@ -177,7 +177,7 @@ class Word {
     }, config.animations.SLIDE_END_DELAY + 200);
   }
 
-  applyHint(i) {
+  pushUp(i) {
     if (this.parent.letterScoreDict[this.myLetters[i]] < config.app.LEARNED_THRESHOLD) {
       this.game.add.tween(this.letterObjects[i]).to({ y: config.GLOBALS.worldTop }, 400, Phaser.Easing.Exponential.Out, true, config.animations.SLIDE_END_DELAY + 200);
       this.game.add.tween(this.pills[i]).to({ y: config.GLOBALS.worldTop }, 400, Phaser.Easing.Exponential.Out, true, config.animations.SLIDE_END_DELAY + 200);


### PR DESCRIPTION
This PR adds a toggle to enable or disable visual cues. When they're disabled, the letter doesn't move up. This was tested on both Chrome and Firefox.

![image](https://user-images.githubusercontent.com/46613478/80264954-e62fd480-8663-11ea-89fc-0c864c51266c.png)

Close #6 