### PR TITLE
Use faded cues when users give the wrong answer

### DIFF
--- a/scripts/game-space.js
+++ b/scripts/game-space.js
@@ -186,7 +186,7 @@ class GameSpace {
     // await delay(config.animations.SLIDE_END_DELAY + 800);
     word.setStyle(0);
     await this.playLetter(letter);
-    await word.updateHint();
+    await word.showHint();
     await this.playLetterSoundAlike(letter);
     this.inputReady = true;
   }
@@ -307,7 +307,7 @@ class GameSpace {
       this.slideLetters();
       await this.playLetter(letter);
       if (this.letterScoreDict[letter] < config.app.LEARNED_THRESHOLD) {
-        await word.updateHint();
+        await word.showHint();
         await this.playLetterSoundAlike(letter);
         word.pushUp(word.currentLetterIndex);
       }
@@ -333,11 +333,11 @@ class GameSpace {
       await this.playLetter(letter);
 
         if (this.mistakeCount === 3) {
-          await word.updateHint(true);
+          await word.showHint();
         }
 
         if (this.mistakeCount === 4) {
-          await word.updateHint();
+          await word.showHint();
           await this.playLetterSoundAlike(letter);
           word.pushUp(word.currentLetterIndex);
         }

--- a/scripts/game-space.js
+++ b/scripts/game-space.js
@@ -87,6 +87,9 @@ class GameSpace {
     this.newLetterArray.sort();
     this.loadLetters();
 
+    this.period = this.parent.sounds.period;
+    this.dash = this.parent.sounds.dash;
+
     let inpelm = document.getElementById('input');
     inpelm.value = '';
     if (!this.game.device.desktop && this.game.device.android) {
@@ -375,6 +378,31 @@ class GameSpace {
       let tmp = audio.play();
       let timeout = tmp.totalDuration || 1;
       await delay(timeout * 1000);
+    }
+  }
+
+  /**
+   * Play the letter in Morse code.
+   *
+   * @param {Letter} letter - The current letter.
+   *
+   * @returns {Promise<void>}
+   */
+  async playMorse(letter) {
+    if (!this.game.have_audio) {
+      return;
+    }
+    for (let i = 0; i < letter.morse.length; i++) {
+      let tmp;
+      if (letter.morse[i] === '\u002D') {
+        tmp = this.dash.play();
+      } else if (letter.morse[i] === '\u002E') {
+        tmp = this.period.play();
+      }
+      await delay(300);
+      if (tmp) {
+        await delay(Math.min(0.601, tmp.totalDuration) * 1000)
+      }
     }
   }
 

--- a/scripts/game-space.js
+++ b/scripts/game-space.js
@@ -307,7 +307,6 @@ class GameSpace {
       this.slideLetters();
       await this.playLetter(letter);
       if (this.letterScoreDict[letter] < config.app.LEARNED_THRESHOLD) {
-        this.game.add.tween(word.pills[word.currentLetterIndex].scale).to({ x: 0, y: 0 }, 500, Phaser.Easing.Back.In, true);
         await word.updateHint();
         await this.playLetterSoundAlike(letter);
         word.pushUp(word.currentLetterIndex);

--- a/scripts/game-space.js
+++ b/scripts/game-space.js
@@ -335,6 +335,7 @@ class GameSpace {
         this.letterScoreDict[letter] = -config.app.LEARNED_THRESHOLD - 2;
       }
 
+      await word.setStyle(word.currentLetterIndex);
       await this.playLetter(letter);
       await word.showHint();
       await this.playHints(word.getCurrentLetter(), this.mistakeCount);

--- a/scripts/game-space.js
+++ b/scripts/game-space.js
@@ -188,10 +188,7 @@ class GameSpace {
     word.setStyle(0);
     await this.playLetter(letter);
     await word.updateHint();
-    if (this.game.have_speech_assistive) {
-      await delay(300);
-      await this.playLetterSoundAlike(letter);
-    }
+    await this.playLetterSoundAlike(letter);
     this.inputReady = true;
   }
 
@@ -313,10 +310,7 @@ class GameSpace {
       if (this.letterScoreDict[letter] < config.app.LEARNED_THRESHOLD) {
         this.game.add.tween(word.pills[word.currentLetterIndex].scale).to({ x: 0, y: 0 }, 500, Phaser.Easing.Back.In, true);
         await word.updateHint();
-        if (this.game.have_speech_assistive) {
-          await delay(300);
-          await this.playLetterSoundAlike(letter);
-        }
+        await this.playLetterSoundAlike(letter);
         word.pushUp(word.currentLetterIndex);
       }
       this.parent.header.updateProgressLights(this.letterScoreDict, theLetterIndex);
@@ -349,10 +343,7 @@ class GameSpace {
 
         if (this.mistakeCount === 4) {
           await word.updateHint();
-          if (this.game.have_speech_assistive) {
-            await delay(300);
-            await this.playLetterSoundAlike(letter);
-          }
+          await this.playLetterSoundAlike(letter);
           word.pushUp(word.currentLetterIndex);
         }
       }
@@ -383,7 +374,8 @@ class GameSpace {
 
   async playLetterSoundAlike(letter) {
     let audio = this.parent.sounds['soundalike-letter-' + letter];
-    if (audio) {
+    if (this.game.have_speech_assistive && audio) {
+      await delay(300);
       let tmp = audio.play();
       let timeout = tmp.totalDuration || 1;
       await delay(timeout * 1000);

--- a/scripts/game-space.js
+++ b/scripts/game-space.js
@@ -25,7 +25,6 @@ class GameSpace {
     this.currentLettersInPlay = [];
     this.currentWords = [];
     this.currentWordIndex = 0;
-    this.hasMistake = false;
     this.mistakeCount = 0;
     this.consecutiveCorrect = 0;
     this.inputReady = false;
@@ -318,7 +317,6 @@ class GameSpace {
       this.mistakeCount++;
       this.consecutiveCorrect = 0;
 
-      let letterMistake = word.letterObjects[word.currentLetterIndex].hasMistake;
       this.letterScoreDict[letter] -= 1;
       word.shake(word.currentLetterIndex);
       // console.log('not a match: ' + typedLetter + ' ' + letter);
@@ -334,8 +332,6 @@ class GameSpace {
       }
 
       await this.playLetter(letter);
-      if (!letterMistake) {
-        letterMistake = true;
 
         if (this.mistakeCount === 3) {
           await word.updateHint(true);
@@ -346,7 +342,6 @@ class GameSpace {
           await this.playLetterSoundAlike(letter);
           word.pushUp(word.currentLetterIndex);
         }
-      }
     }
     this.inputReady = true;
   }

--- a/scripts/game-space.js
+++ b/scripts/game-space.js
@@ -186,8 +186,10 @@ class GameSpace {
     // await delay(config.animations.SLIDE_END_DELAY + 800);
     word.setStyle(0);
     await this.playLetter(letter);
-    await word.showHint();
-    await this.playLetterSoundAlike(letter);
+    if (this.letterScoreDict[letter] < config.app.LEARNED_THRESHOLD) {
+      await word.showHint();
+      await this.playLetterSoundAlike(letter);
+    }
     this.inputReady = true;
   }
 

--- a/scripts/game-space.js
+++ b/scripts/game-space.js
@@ -186,10 +186,7 @@ class GameSpace {
 
     // await delay(config.animations.SLIDE_END_DELAY + 800);
     word.setStyle(0);
-    if (this.game.have_speech_assistive) {
-      // play the letter again
-      await this.playLetter(letter);
-    }
+    await this.playLetter(letter);
     await word.updateHint();
     if (this.game.have_speech_assistive) {
       await delay(300);
@@ -312,10 +309,7 @@ class GameSpace {
       let theLetterIndex = this.newLetterArray.indexOf(typedLetter);
 
       this.slideLetters();
-      if (this.game.have_speech_assistive) {
-        // play the letter again
-        await this.playLetter(letter);
-      }
+      await this.playLetter(letter);
       if (this.letterScoreDict[letter] < config.app.LEARNED_THRESHOLD) {
         this.game.add.tween(word.pills[word.currentLetterIndex].scale).to({ x: 0, y: 0 }, 500, Phaser.Easing.Back.In, true);
         await word.updateHint();
@@ -345,10 +339,7 @@ class GameSpace {
         this.letterScoreDict[letter] = -config.app.LEARNED_THRESHOLD - 2;
       }
 
-      if (this.game.have_speech_assistive) {
-        // play the letter again
-        await this.playLetter(letter);
-      }
+      await this.playLetter(letter);
       if (!letterMistake) {
         letterMistake = true;
 
@@ -383,7 +374,7 @@ class GameSpace {
 
   async playLetter(letter) {
     let audio = this.parent.sounds['letter-' + letter];
-    if (audio) {
+    if (this.game.have_speech_assistive && audio) {
       let tmp = audio.play();
       let timeout = tmp.totalDuration || 1;
       await delay(timeout * 1000);

--- a/scripts/word.js
+++ b/scripts/word.js
@@ -75,7 +75,6 @@ class Word {
       letter.alpha = 0.2;
       letter.morse = this.parent.parent.morseDictionary[this.myLetters[i]];
       letter.fill = '#000000';
-      letter.hasMistake = false;
       this.letterObjects.push(letter);
 
       let hint = this.game.add.sprite(config.app.wordBrickSize, config.GLOBALS.worldCenter + 50, 'e');

--- a/scripts/word.js
+++ b/scripts/word.js
@@ -26,6 +26,7 @@ class Word {
 
   create(morseVisible, myWord) {
     this.myLetters = [];
+    /** @type {Array<Letter>} */
     this.letterObjects = [];
     this.hints = [];
     this.pills = [];
@@ -37,6 +38,11 @@ class Word {
     for (let i = 0; i < this.myLength; i++) {
       this.myLetters.push(myWord[i])
     }
+  }
+
+  /** @returns {Letter} */
+  getCurrentLetter() {
+    return this.letterObjects[this.currentLetterIndex];
   }
 
   setPosition(startX) {
@@ -65,7 +71,14 @@ class Word {
       circle.endFill();
       this.pills.push(circle);
 
-      // Letter
+      /**
+       * A game letter.
+       *
+       * @typedef {Phaser.Text} Letter
+       *
+       * @property {string} letter - The lowercase letter.
+       * @property {string} morse - The letter in Morse code.
+       */
       let letter = this.game.add.text(startX + (i * config.app.wordBrickSize), config.GLOBALS.worldCenter, this.myLetters[i].toUpperCase());
       letter.font = config.typography.font;
       letter.fontWeight = 600;
@@ -75,6 +88,7 @@ class Word {
       letter.alpha = 0.2;
       letter.morse = this.parent.parent.morseDictionary[this.myLetters[i]];
       letter.fill = '#000000';
+      letter.letter = this.myLetters[i];
       this.letterObjects.push(letter);
 
       let hint = this.game.add.sprite(config.app.wordBrickSize, config.GLOBALS.worldCenter + 50, 'e');

--- a/scripts/word.js
+++ b/scripts/word.js
@@ -131,21 +131,12 @@ class Word {
     });
   }
 
-  async updateHint(textOnly) {
+  async showHint() {
     if (this.hints.length !== 0) {
-      if (textOnly) {
-        this.game.add.tween(this.hints[this.currentLetterIndex].text).to({ alpha: 1 }, 200, Phaser.Easing.Linear.In, true);
-      } else {
-        await delay(config.animations.SLIDE_END_DELAY + 400);
-        if (this.game.have_visual_cues) {
-          this.game.add.tween(this.hints[this.currentLetterIndex].image).to({ alpha: 1 }, 200, Phaser.Easing.Linear.In, true);
-        }
-        this.game.add.tween(this.hints[this.currentLetterIndex].text).to({ alpha: 1 }, 200, Phaser.Easing.Linear.In, true);
-        // Play the sounds when hint image shows
-        await this.playSounds(this.letterObjects[this.currentLetterIndex]);
+      await delay(config.animations.SLIDE_END_DELAY + 400);
+      if (this.game.have_visual_cues) {
+        this.game.add.tween(this.hints[this.currentLetterIndex].image).to({ alpha: 1 }, 200, Phaser.Easing.Linear.In, true);
       }
-
-      this.game.add.tween(this.hints[this.currentLetterIndex].underline).to({ alpha: 1 }, 200, Phaser.Easing.Linear.In, true);
     }
   }
 

--- a/scripts/word.js
+++ b/scripts/word.js
@@ -140,26 +140,6 @@ class Word {
     }
   }
 
-  // Play individual dots/dash sound
-  // Using 601ms for the delay between each sound because thats the dash duration
-  // Which is the longest duration of the sounds
-  async playSounds(letter) {
-    if (!this.game.have_audio) {
-      return;
-    }
-    for (let i = 0; i < letter.morse.length; i++) {
-      let tmp;
-      if (letter.morse[i] === '\u002D') {
-        tmp = this.dash.play();
-      } else if (letter.morse[i] === '\u002E') {
-        tmp = this.period.play();
-      }
-      if (tmp) {
-        await delay(Math.min(0.601, tmp.totalDuration) * 1000)
-      }
-    }
-  }
-
   setStyle(i) {
     this.pushUp(i);
     this.game.add.tween(this.letterObjects[i]).to({ alpha: 1 }, 200, Phaser.Easing.Linear.Out, true, config.animations.SLIDE_END_DELAY + 200);


### PR DESCRIPTION
This PR does a few things:

- Implement the behaviour outlined in https://github.com/AceCentre/morse-learn/issues/8#issuecomment-626042107 for audio cues.
- Write a few JSDoc comments to document expected types. IDEs like WebStorm and VS Code can parse the annotations and catch mistakes like passing a string argument instead of a number. (We could look into TypeScript eventually.)
- Fix a few discrepancies, like the pill not appearing for learned letters.

I think I did a good round of QA, but I suggest you do the same @willwade. I also recommend reviewing commit by commit.

Close #8