### PR TITLE
Randomise settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -165,6 +165,13 @@
           settings. You will be tracked with a cookie, but we won’t save any
           personal data.
         </p>
+        <p>
+          For our collection we need to collect data from a variety of game setting configurations. To achieve this we would like to randomise your settings. You can change your settings at any time.
+        </p>
+        <label>
+          <input type="checkbox" id="randomiseSettings" checked/>
+          Randomise my settings
+        </label>
         <p class="strong">
           If you are okay with us collecting this data press the button below
           and get playing!

--- a/index.html
+++ b/index.html
@@ -156,9 +156,7 @@
         <p>
           Ace Centre are researching into the time it takes people to learn
           morse code with different learning methods. To enable this we need to collect
-          some anonymous data as you learn. We will only collect your playtime,
-          your progress and your game settings. You will be tracked with a
-          cookie, but we won’t save any personal data.
+          some <strong>anonymous</strong> data as you learn.
         </p>
         <p>
           We will only collect your play time, your progress and your game

--- a/scripts/title-state.js
+++ b/scripts/title-state.js
@@ -29,6 +29,8 @@ const getBoolFromLocalStore = (key) => {
   return false
 }
 
+const randomBoolean = () => Math.random() < 0.5;
+
 class TitleState {
   constructor(game, course) {
     this.course = course;
@@ -62,6 +64,25 @@ class TitleState {
 
       consentYesButton.addEventListener('click', () => {
         localStorage.setItem(TRACKING_ALLOWED_KEY, true);
+
+        const randomiseSettings = document.getElementById('randomiseSettings').checked
+
+        if(randomiseSettings) {
+          const audio = randomBoolean()
+          let speechAssistive = randomBoolean()
+          const visualCues = randomBoolean()
+
+          // Not perfectly random but means we don't get invalid settings
+          if(audio === false) {
+            speechAssistive = false;
+          }
+
+          console.log('Going to randomise your settings:', {speechAssistive, audio, visualCues})
+          localStorage.setItem('have_speech_assistive', speechAssistive)
+          localStorage.setItem('have_audio', audio)
+          localStorage.setItem('have_visual_cues', visualCues)
+        }
+
         consentModal.style.display = 'none';
         cb()
       })


### PR DESCRIPTION
We pick a random value for the following settings:

* Audio
* Speech Prompts
* Visual Prompts

If audio is generated as false then speech prompts will also be forced to false.

The user can decide if we randomise their settings. The default is that we will randomise them.

The consent modal now looks like this: 

![Screenshot 2021-05-14 at 16 37 51](https://user-images.githubusercontent.com/1359202/118294542-bb185d00-b4d2-11eb-9b8c-f2007576fad8.png)
